### PR TITLE
use https instead of ftp

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -20,7 +20,7 @@ my $builder = Alien::Base::ModuleBuild->new(
   alien_name => 'gsl',
   alien_repository => [
     {
-      protocol => 'ftp',
+      protocol => 'https',
       host     => 'ftp.gnu.org',
       location => '/gnu/gsl',
       pattern  => qr/^gsl-([\d\.]+)\.tar\.gz$/,


### PR DESCRIPTION
http is more reliable than ftp with a lot of environments blocking ftp.  https is safer for security and stuff.

/ cc: @thibaultduponchelle